### PR TITLE
fix uninitialized variable

### DIFF
--- a/c/openedu.c
+++ b/c/openedu.c
@@ -87,7 +87,7 @@ int openedu_printf(char *fmt_string, ...) {
     int rv;
     va_list args;
     va_start(args, fmt_string);
-    vfprintf(ouf, fmt_string, args);
+    rv = vfprintf(ouf, fmt_string, args);
     va_end(args);
     return rv;
 }


### PR DESCRIPTION
```
$ gcc example.c openedu.c -Wall                                         
openedu.c: In function ‘openedu_printf’:
openedu.c:92:5: warning: ‘rv’ is used uninitialized in this function [-Wuninitialized]
     return rv;
```